### PR TITLE
fix: remediate credential leak in config.json (#12)

### DIFF
--- a/.changeset/credential-cleanup.md
+++ b/.changeset/credential-cleanup.md
@@ -1,0 +1,5 @@
+---
+"schem-sync-portal": patch
+---
+
+fix: remove plaintext credentials from config.json to prevent security leaks

--- a/src/hooks/useWizardAuth.ts
+++ b/src/hooks/useWizardAuth.ts
@@ -48,7 +48,7 @@ export function useWizardAuth({
             if (method === "webdav") {
                 const { createWebDavRemote } = await import("../lib/rclone");
                 await createWebDavRemote(Env.REMOTE_PORTAL_SOURCE, url, user || "", pass || "");
-                updateConfig(prev => ({ ...prev, source_provider: "copyparty", copyparty_method: "webdav", webdav_user: user, webdav_pass: pass }));
+                updateConfig(prev => ({ ...prev, source_provider: "copyparty", copyparty_method: "webdav" }));
                 next();
             } else {
                 if (!pass) { setAuthStatus("⚠️ Password required."); setIsAuthLoading(false); return; }
@@ -56,7 +56,7 @@ export function useWizardAuth({
                 if (cookie) {
                     const { createHttpRemote } = await import("../lib/rclone");
                     await createHttpRemote(Env.REMOTE_PORTAL_SOURCE, url, cookie);
-                    updateConfig(prev => ({ ...prev, source_provider: "copyparty", copyparty_method: "http", cookie }));
+                    updateConfig(prev => ({ ...prev, source_provider: "copyparty", copyparty_method: "http" }));
                     next();
                 } else setAuthStatus("❌ Auth failed.");
             }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -36,10 +36,7 @@ export interface PortalConfig {
     debug_mode: boolean;
     log_level?: LogLevel;
     nerd_font_version?: 2 | 3;
-    cookie?: string;
     copyparty_method?: "webdav" | "http";
-    webdav_user?: string;
-    webdav_pass?: string;
 
     // Font Presence tracking
     nerd_font_auto_install?: boolean;
@@ -103,6 +100,11 @@ export function loadConfig(): PortalConfig {
                 parsed.log_level = "NORMAL";
             }
 
+            // MIGRATION: SECURITY HARDENING - Remove plaintext credentials (Issue #12)
+            if (parsed.cookie) delete parsed.cookie;
+            if (parsed.webdav_user) delete parsed.webdav_user;
+            if (parsed.webdav_pass) delete parsed.webdav_pass;
+
             return { ...EMPTY_CONFIG, ...parsed };
         }
     } catch (err: unknown) {
@@ -136,10 +138,7 @@ export function saveConfig(config: PortalConfig): void {
             debug_mode: config.debug_mode,
             log_level: config.log_level || "NORMAL",
             nerd_font_version: config.nerd_font_version,
-            cookie: config.cookie,
             copyparty_method: config.copyparty_method,
-            webdav_user: config.webdav_user,
-            webdav_pass: config.webdav_pass,
             nerd_font_auto_install: config.nerd_font_auto_install,
             nerd_font_auto_install_dismissed: config.nerd_font_auto_install_dismissed,
             nerd_font_installed_family: config.nerd_font_installed_family,

--- a/src/lib/sync/pullPhase.ts
+++ b/src/lib/sync/pullPhase.ts
@@ -18,13 +18,11 @@ import type { SyncProgress, ManifestStats, CleanupStats } from "./types";
  */
 async function discoverManifest(config: PortalConfig, sourceRemote: string): Promise<string | null> {
     const localManifest = join(config.local_dir, "manifest.txt");
-    const sourceFlags = (config.source_provider === "copyparty" && config.cookie) ? ["--header", config.cookie] : [];
 
     try {
         Logger.debug("SYNC", "Checking for remote manifest.txt...");
         await executeRclone([
             "copyto", `${sourceRemote}manifest.txt`, localManifest,
-            ...sourceFlags,
             ...RETRY_FLAGS
         ], () => { }, undefined, "download", "pull");
         return localManifest;
@@ -180,7 +178,6 @@ export async function runPullPhase(
 
     const basePullArgs = [
         config.strict_mirror ? "sync" : "copy", sourceRemote, config.local_dir,
-        ...(config.source_provider === "copyparty" && config.cookie ? ["--header", config.cookie] : []),
         "--size-only", "--fast-list",
         "--transfers", String(config.downsync_transfers || 4),
         "--checkers", "16",


### PR DESCRIPTION
This PR implements the security remediations suggested by Traycer.ai for issue #12. 

### Key Changes:
- **Schema Update**: Removed , , and  from  in .
- **Migration Logic**: Added logic to  to automatically strip these fields from existing  files upon loading.
- **Wizard Update**: Updated  to stop saving these credentials to the local configuration.
- **Sync Engine**: Removed the use of  flags for cookies in , as rclone remotes handle authentication securely.