### PR TITLE
docs: align README and CHANGELOG with v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.5.1
+
+### Patch Changes
+
+- Resolve wizard authentication ref type inconsistencies and improve auth logic in `useWizardAuth.ts`.
+- Fix function signature mismatches in wizard components to align with updated auth hooks.
+- Add `displayName` to all wizard and UI components for full OpenTUI linter compliance.
+
 ## 1.5.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 📜 Schematic Sync Portal - ****BETA****
 > **Surgical Schematic Sync for the Repair Community**
 
-![Version](https://img.shields.io/badge/version-1.4.0-blue)
+![Version](https://img.shields.io/badge/version-1.5.1-blue)
 ![License](https://img.shields.io/badge/license-Custom--Attribution-blue)
 
 The **Schematic Sync Portal** is a TUI (Terminal User Interface) application designed to update local schematic archives from a cloud source and optionaly create redundant cloud backups.


### PR DESCRIPTION
This PR aligns the project documentation with the current version (1.5.1) and git tags.\n\n### Changes\n- Updated `README.md` version badge to 1.5.1.\n- Added missing release notes for 1.5.1 to `CHANGELOG.md`, covering recent wizard and authentication logic improvements.